### PR TITLE
[pvr] matching EPG tag pointers means an absolute match between a tim…

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -629,10 +629,12 @@ CFileItemPtr CPVRTimers::GetTimerForEpgTag(const CFileItem *item) const
       for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
       {
         CPVRTimerInfoTagPtr timer = *timerIt;
-        if (timer->m_iClientChannelUid == channel->UniqueID() &&
+
+        if (timer->GetEpgInfoTag() == epgTag || 
+            (timer->m_iClientChannelUid == channel->UniqueID() &&
             timer->m_bIsRadio == channel->IsRadio() &&
             timer->StartAsUTC() <= epgTag->StartAsUTC() &&
-            timer->EndAsUTC() >= epgTag->EndAsUTC())
+            timer->EndAsUTC() >= epgTag->EndAsUTC()))
         {
           CFileItemPtr fileItem(new CFileItem(timer));
           return fileItem;


### PR DESCRIPTION
…er and an

EPG tag

Some backends may consider recordings to have started when the actual recording
started, not when the recorded programme starts. This means the start time
differs and the timer/recording cannot be matched with the corresponding EPG
tag.